### PR TITLE
Adjust markdown on readme to be parsed correctly by npmjs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Gulp prompt
+# Gulp prompt
 
 Add interaction to gulp tasks.
 
-##.confirm([options])
+## .confirm([options])
 
 Options:
 
@@ -41,7 +41,7 @@ gulp.src('test.js')
 
 ```
 
-##.prompt(questions, callback)
+## .prompt(questions, callback)
 
 This is a clean pass-through function for gulp to utilize the full [Inquirer.js Library](https://github.com/SBoudrias/Inquirer.js), please refer to them for documentation on corresponding parameters.
 


### PR DESCRIPTION
# Problem

On [npmjs.org](https://www.npmjs.com/package/gulp-prompt), the `#` to denote headers only apply if there is a space between the `#` and the word. Without the space, the readme ends up looking like this:

![screen shot 2015-09-07 at 2 37 16 pm](https://cloud.githubusercontent.com/assets/2916945/9722186/1e3ae3d2-556e-11e5-9ccf-aed3e4619966.png)

# Solution

Add spaces between the `#` and the heading.