### PR TITLE
Check in fix for release version name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2017-12-04
+### Added
+- Fix Release name to be v-1.0.0 to following convention  @shannonlal
+
 ## [1.0.0] - 2017-11-30
 ### Added
 - Added first prod release since there are now outstanding issues  @shannonlal


### PR DESCRIPTION
This is a fix for issue #53.  The release name should have been v-1.0.0 to follow the correct semaver naming convention.  The npm and package name were correct but the release name was incorrect