### PR TITLE
Added fix for removing let dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## [1.0.1] - 2017-12-19
+### Added
+- Removed dependency on let to fix issue #55  @shannonlal
 
 ## [1.0.0] - 2017-12-04
 ### Added

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = {
 
   confirm: function(options) {
     var prompted = false;
-    let chainFunction;
+    var chainFunction;
     return es.map(function(file, cb) {
 
       if (prompted === true) {
@@ -57,7 +57,7 @@ module.exports = {
         
         return new Promise( (resolve,reject)=>{
             inq.prompt([options]).then( resp =>{
-              let opts = chainFunction( options, resp );
+              var opts = chainFunction( options, resp );
               if( typeof opts === 'undefined'){
                 return resolve('response');
               }else{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-prompt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Add interactive console prompts to gulp",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
An issue was raised (#55 ) today about the use of the let keyword.  It was only used in two locations and I felt it was easy to remove the dependency so it doesn't cause any backward compatibility issues.  